### PR TITLE
LDEV-6179 fix race condition in readConfig() and restructure init lifecycle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,6 +187,7 @@ jobs:
           sed -i 's/port="8080"/port="8888"/g' lucee-express/conf/server.xml
 
       - name: Warmup Lucee Express
+        if: false  # disabled to test cold-start without warmup masking race conditions
         run: |
           cd lucee-express
           echo "Running Lucee warmup..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: Java CI Combined
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   push:
   pull_request:
@@ -39,16 +36,16 @@ jobs:
       version: ${{ steps.extract-version.outputs.VERSION }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -73,7 +70,7 @@ jobs:
           echo "| Artifact | \`websocket-extension-${{ steps.extract-version.outputs.VERSION }}.lex\` |" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload extension
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: extension-lex
           path: target/*.lex
@@ -96,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Determine Tomcat and Java version
         id: config
@@ -118,13 +115,13 @@ jobs:
           esac
 
       - name: Set up JDK ${{ steps.config.outputs.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '${{ steps.config.outputs.java }}'
           distribution: 'temurin'
 
       - name: Download extension
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: extension-lex
           path: extension
@@ -159,7 +156,7 @@ jobs:
       - name: Download websocket-client extension
         run: |
           echo "Downloading websocket-client extension..."
-          curl -L -o websocket-client.lex "https://ext.lucee.org/websocket-client-extension-2.3.0.8-SNAPSHOT.lex"
+          curl -L -o websocket-client.lex "https://ext.lucee.org/websocket-client-extension-2.3.0.9-SNAPSHOT.lex"
           ls -la websocket-client.lex
 
       - name: Install extensions into Express
@@ -314,7 +311,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lucee-logs-${{ steps.lucee-jar.outputs.LUCEE_VERSION }}
           path: |
@@ -327,16 +324,16 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.test.result == 'success' && !inputs.dry-run
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: maven-${{ hashFiles('**/pom.xml') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 3.0.0.20
+
+- [LDEV-6179](https://luceeserver.atlassian.net/browse/LDEV-6179) — fix race condition in `readConfig()` causing `this.mapping is null` on startup
+- [LDEV-6179](https://luceeserver.atlassian.net/browse/LDEV-6179) — restructure init lifecycle: separate data creation, component init, and endpoint registration
+- [LDEV-6179](https://luceeserver.atlassian.net/browse/LDEV-6179) — lazy retry for mapping init instead of permanent failure on first error
+- Fix `inject()` self-delegation causing infinite recursion in `onError`
+- CI: dynamic Lucee version matrix, workflow_dispatch for version bisecting, always upload logs
+
+## 3.0.0.19
+
+- [LDEV-6050](https://luceeserver.atlassian.net/browse/LDEV-6050) — support jakarta WebSocket API (Lucee 7.x / Tomcat 11)
+- Add GAV to Maven POM
+
+## 3.0.0.18
+
+- [LDEV-6050](https://luceeserver.atlassian.net/browse/LDEV-6050) — fix websocket extension not loading on Lucee 7.x
+- Update Maven POM with new Sonatype endpoint
+
+## 3.0.0.17
+
+- [LDEV-5385](https://luceeserver.atlassian.net/browse/LDEV-5385) — include websocket jars with extension, add `Require-Bundle`
+- Use single ConfigWeb when only one is available
+
+## 3.0.0.16
+
+- [LDEV-5385](https://luceeserver.atlassian.net/browse/LDEV-5385) — resolve class loading conflicts between javax and jakarta namespaces
+- Add tests and CI workflow
+- Add Maven deployment
+
+## Earlier versions
+
+- WebSocket idle timeout and request timeout support
+- `websocketInfo()` BIF with version, instances, and session info
+- Runtime extension update via `inject()`
+- Initial javax.websocket implementation

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lucee</groupId>
     <artifactId>websocket-extension</artifactId>
-    <version>3.0.0.19-SNAPSHOT</version>
+    <version>3.0.0.20-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Websocket Extension</name>
 

--- a/source/java/src/org/lucee/extension/websocket/BaseWebSocketEndpoint.java
+++ b/source/java/src/org/lucee/extension/websocket/BaseWebSocketEndpoint.java
@@ -80,6 +80,8 @@ public class BaseWebSocketEndpoint {
 	}
 
 	public static void inject(Object nv) {
+		// guard against self-delegation which causes infinite recursion
+		if (nv instanceof BaseWebSocketEndpoint) return;
 		newerVersion = nv;
 	}
 

--- a/source/java/src/org/lucee/extension/websocket/WebSocketEndpointFactory.java
+++ b/source/java/src/org/lucee/extension/websocket/WebSocketEndpointFactory.java
@@ -10,7 +10,6 @@ import org.lucee.extension.websocket.util.WSUtil;
 import org.lucee.extension.websocket.util.print;
 import org.osgi.framework.Bundle;
 
-import lucee.commons.io.log.Log;
 import lucee.commons.io.res.Resource;
 import lucee.loader.engine.CFMLEngine;
 import lucee.loader.engine.CFMLEngineFactory;
@@ -78,12 +77,117 @@ public class WebSocketEndpointFactory {
 		}
 	}
 
-	private void register() {
+	// get or create the Data entry for a web context (always succeeds, thread-safe)
+	private Data getOrCreateData(ConfigWeb cw) {
+		return datas.computeIfAbsent(cw.getIdentification().getId(), k -> new Data(cw));
+	}
+
+	// read config, create mapping, set timeouts for a web context
+	private void initContextComponents(Data data, PageContext pc) throws PageException, IOException {
+		Object[] arr = WSUtil.readConfig(pc);
+		data.configFile = (Resource) arr[0];
+		data.configuration = (Struct) arr[1];
+
+		// directory
+		String path = eng.getCastUtil().toString(data.configuration.get("directory", null), null);
+		if (eng.getStringUtil().isEmpty(path, true)) {
+			WSUtil.info(pc.getConfig(), "no [directory] setting found in configuration, using default location [" + WSUtil.DEFAULT_DIRECTORY + "]");
+			path = WSUtil.DEFAULT_DIRECTORY;
+			if (data.configuration == null) data.configuration = eng.getCreationUtil().createStruct();
+			data.configuration.setEL("directory", path);
+		}
+		else {
+			WSUtil.info(pc.getConfig(), "found [directory] setting in configuration, using [" + path + "]");
+		}
+		data.mapping = WSUtil.createMapping(pc, path);
+
+		// request timeout
+		long timeout = eng.getCastUtil().toLongValue(data.configuration.get("requestTimeout", null), 0);
+		if (timeout > 0L) data.requestTimeout = timeout * 1000;
+
+		// idle timeout
+		timeout = eng.getCastUtil().toLongValue(data.configuration.get("idleTimeout", null), 0);
+		if (timeout > 0L) data.idleTimeout = timeout * 1000;
+
+		ConfigWeb cw = pc.getConfig();
+		WSUtil.info(cw, "init WebSocketEndpoint for web context [" + cw.getIdentification().getId() + " - " + WSUtil.getServletContextRealPath(cw, "/")
+				+ "] mapping defined in the configuration is [" + path + "], this is resolved to [" + data.mapping.getPhysical() + "]");
+	}
+
+	// register the websocket endpoint with the servlet container (one-time, thread-safe)
+	private void registerEndpoint(ConfigWeb cw) throws PageException {
+		if (isEndpointRegistered) return;
+		synchronized (token) {
+			if (isEndpointRegistered) return;
+			Properties props = System.getProperties();
+			Object endpoint = props.get("lucee.websocket.endpoint");
+
+			// update
+			if (endpoint instanceof Class) {
+				String msg = "update existing WebSocketEndpoint with via injection";
+				WSUtil.info(cs, msg);
+				WSUtil.info(cw, msg);
+
+				CFMLEngine eng = CFMLEngineFactory.getInstance();
+				try {
+					if (WSUtil.getContainerType(cw) == WSUtil.TYPE_JAKARTA)
+						eng.getClassUtil().callStaticMethod((Class) endpoint, "inject", new Object[] { new JakartaWebSocketEndpoint() });
+					else if (WSUtil.getContainerType(cw) == WSUtil.TYPE_JAVAX)
+						eng.getClassUtil().callStaticMethod((Class) endpoint, "inject", new Object[] { new JavaxWebSocketEndpoint() });
+				}
+				catch (PageException e) {
+					print.e(e);
+					throw e;
+				}
+			}
+			// add
+			else {
+				String msg = "register WebSocketEndpoint with servlet container";
+				WSUtil.info(cs, msg);
+				WSUtil.info(cw, msg);
+				try {
+
+					Object oServerContainer = WSUtil.getServletContextAttribute(cw,
+							(WSUtil.getContainerType(cw) == WSUtil.TYPE_JAKARTA ? "jakarta" : "javax") + ".websocket.server.ServerContainer");
+
+					if (WSUtil.getContainerType(cw) == WSUtil.TYPE_JAKARTA) {
+						props.put("lucee.websocket.endpoint", JAKARTA_ENDPOINT_CLASS);
+						((jakarta.websocket.server.ServerContainer) oServerContainer).addEndpoint(JAKARTA_ENDPOINT_CLASS);
+					}
+					else if (WSUtil.getContainerType(cw) == WSUtil.TYPE_JAVAX) {
+						props.put("lucee.websocket.endpoint", JAVAX_ENDPOINT_CLASS);
+						((javax.websocket.server.ServerContainer) oServerContainer).addEndpoint(JAVAX_ENDPOINT_CLASS);
+					}
+					else {
+						if (oServerContainer == null)
+							throw eng.getExceptionUtil().createApplicationException("[javax.websocket.server.ServerContainer] not supported on this server.");
+						else throw eng.getExceptionUtil()
+								.createApplicationException("container [" + oServerContainer.getClass().getName()
+										+ "] not supported, only the following container are supported [" + jakarta.websocket.server.ServerContainer.class.getName() + ", "
+										+ javax.websocket.server.ServerContainer.class.getName() + "].");
+					}
+				}
+
+				catch (jakarta.websocket.DeploymentException | javax.websocket.DeploymentException e) {
+					// some container are not able/do not allow to update the endpoint, but this is needed when the
+					// extension updates, so we inject us in the old extension version
+					throw eng.getCastUtil().toPageException(e);
+				}
+			}
+			isEndpointRegistered = true;
+		}
+
+		// inject(Object nv)
+	}
+
+	// called by the Registrar thread to discover and register new web contexts
+	private void scanWebContexts() {
 		for (ConfigWeb cw: cs.getConfigWebs()) {
 			try {
 				// Skip CLI servlet contexts
 				if (cw != null && !WSUtil.isCliServletContext(cw)) {
-					register(cw);
+					getOrCreateData(cw);
+					registerEndpoint(cw);
 				}
 			}
 			catch (Exception e) {
@@ -92,99 +196,23 @@ public class WebSocketEndpointFactory {
 		}
 	}
 
-	private Data register(ConfigWeb cw) throws PageException {
-		Data data = datas.get(cw.getIdentification().getId());
-		if (data != null) return data;
-
-		datas.put(cw.getIdentification().getId(), data = new Data(cw));
-
-		try {
-			if (WSUtil.hasLogLevel(cw, Log.LEVEL_INFO) || data.mapping == null) {
-				PageContext pc = WSUtil.createPageContext(this, cw, null, null);
-				data.mapping = getComponentMapping(pc);
-				String msg = "register web context  [" + cw.getIdentification().getId() + " - " + WSUtil.getServletContextRealPath(cw, "/")
-						+ "] mapping defined in the configuration is [" + data.mapping.getPhysical() + "]";
-				WSUtil.info(cs, msg);
-				WSUtil.info(cw, msg);
-			}
-		}
-		catch (Exception e) {
-			WSUtil.error(cs, e);
-			WSUtil.error(cw, e);
-		}
-
-		if (!isEndpointRegistered) {
-			synchronized (token) {
-				if (!isEndpointRegistered) {
-					Properties props = System.getProperties();
-					Object endpoint = props.get("lucee.websocket.endpoint");
-
-					// update
-					if (endpoint instanceof Class) {
-						String msg = "update existing WebSocketEndpoint with via injection";
-						WSUtil.info(cs, msg);
-						WSUtil.info(cw, msg);
-
-						CFMLEngine eng = CFMLEngineFactory.getInstance();
-						try {
-							if (WSUtil.getContainerType(cw) == WSUtil.TYPE_JAKARTA)
-								eng.getClassUtil().callStaticMethod((Class) endpoint, "inject", new Object[] { new JakartaWebSocketEndpoint() });
-							else if (WSUtil.getContainerType(cw) == WSUtil.TYPE_JAVAX)
-								eng.getClassUtil().callStaticMethod((Class) endpoint, "inject", new Object[] { new JavaxWebSocketEndpoint() });
-						}
-						catch (PageException e) {
-							print.e(e);
-							throw e;
-						}
-					}
-					// add
-					else {
-						String msg = "register WebSocketEndpoint with servlet container";
-						WSUtil.info(cs, msg);
-						WSUtil.info(cw, msg);
-						try {
-
-							Object oServerContainer = WSUtil.getServletContextAttribute(cw,
-									(WSUtil.getContainerType(cw) == WSUtil.TYPE_JAKARTA ? "jakarta" : "javax") + ".websocket.server.ServerContainer");
-
-							if (WSUtil.getContainerType(cw) == WSUtil.TYPE_JAKARTA) {
-								props.put("lucee.websocket.endpoint", JAKARTA_ENDPOINT_CLASS);
-								((jakarta.websocket.server.ServerContainer) oServerContainer).addEndpoint(JAKARTA_ENDPOINT_CLASS);
-							}
-							else if (WSUtil.getContainerType(cw) == WSUtil.TYPE_JAVAX) {
-								props.put("lucee.websocket.endpoint", JAVAX_ENDPOINT_CLASS);
-								((javax.websocket.server.ServerContainer) oServerContainer).addEndpoint(JAVAX_ENDPOINT_CLASS);
-							}
-							else {
-								if (oServerContainer == null)
-									throw eng.getExceptionUtil().createApplicationException("[javax.websocket.server.ServerContainer] not supported on this server.");
-								else throw eng.getExceptionUtil()
-										.createApplicationException("container [" + oServerContainer.getClass().getName()
-												+ "] not supported, only the following container are supported [" + jakarta.websocket.server.ServerContainer.class.getName() + ", "
-												+ javax.websocket.server.ServerContainer.class.getName() + "].");
-							}
-						}
-
-						catch (jakarta.websocket.DeploymentException | javax.websocket.DeploymentException e) {
-							// some container are not able/do not allow to update the endpoint, but this is needed when the
-							// extension updates, so we inject us in the old extension version
-							throw eng.getCastUtil().toPageException(e);
-						}
-					}
-					isEndpointRegistered = true;
-				}
-
-			}
-
-		}
-
-		// inject(Object nv)
-
-		return data;
-	}
-
 	public Struct getInfo(ConfigWeb config, boolean addRaw) throws PageException {
-		return register(config).getInfo(addRaw);
+		Data data = getOrCreateData(config);
+		if (data.mapping == null) {
+			// lazy init — retry if previous attempt failed
+			PageContext pc = WSUtil.createPageContext(this, config, null, null);
+			try {
+				initContextComponents(data, pc);
+			}
+			catch (Exception e) {
+				throw eng.getCastUtil().toPageException(e);
+			}
+			finally {
+				WSUtil.releasePageContext(pc);
+			}
+		}
+		registerEndpoint(config);
+		return data.getInfo(addRaw);
 	}
 
 	public static WebSocketEndpointFactory getInstance() throws PageException {
@@ -207,38 +235,11 @@ public class WebSocketEndpointFactory {
 
 	public Mapping getComponentMapping(PageContext pc) throws PageException, IOException {
 		ConfigWeb cw = pc.getConfig();
-		Data data = register(cw);
-		if (data.mapping != null) {
-			return data.mapping;
+		Data data = getOrCreateData(cw);
+		if (data.mapping == null) {
+			// lazy init — retry if previous attempt failed
+			initContextComponents(data, pc);
 		}
-		Object[] arr = WSUtil.readConfig(pc);
-		data.configFile = (Resource) arr[0];
-		data.configuration = (Struct) arr[1];
-
-		// directory
-		String path = eng.getCastUtil().toString(data.configuration.get("directory", null), null);
-		if (eng.getStringUtil().isEmpty(path, true)) {
-			WSUtil.info(pc.getConfig(), "no [directory] setting found in configuration, using default location [" + WSUtil.DEFAULT_DIRECTORY + "]");
-			path = WSUtil.DEFAULT_DIRECTORY;
-			if (data.configuration == null) data.configuration = eng.getCreationUtil().createStruct();
-			data.configuration.setEL("directory", path);
-		}
-		else {
-			WSUtil.info(pc.getConfig(), "found [directory] setting in configuration, using [" + path + "]");
-		}
-		data.mapping = WSUtil.createMapping(pc, path);
-
-		WSUtil.info(cw, "init WebSocketEndpoint for web context [" + cw.getIdentification().getId() + " - " + WSUtil.getServletContextRealPath(cw, "/")
-				+ "] mapping defined in the configuration is [" + path + "], this is resolved to [" + data.mapping.getPhysical() + "]");
-
-		// request timeout
-		long timeout = eng.getCastUtil().toLongValue(data.configuration.get("requestTimeout", null), 0);
-		if (timeout > 0L) data.requestTimeout = timeout * 1000;
-
-		// idle timeout
-		timeout = eng.getCastUtil().toLongValue(data.configuration.get("idleTimeout", null), 0);
-		if (timeout > 0L) data.idleTimeout = timeout * 1000;
-
 		return data.mapping;
 	}
 
@@ -262,7 +263,7 @@ public class WebSocketEndpointFactory {
 				if (count == 20) sleepTime = 10000; // after 10 seconds we increase to a 10 second interval
 				else if (count == 30) sleepTime = 60000; // after an other 100 seconds we increase to a minute interval
 				try {
-					factory.register();
+					factory.scanWebContexts();
 
 				}
 				catch (Exception e) {
@@ -285,24 +286,24 @@ public class WebSocketEndpointFactory {
 		}
 	}
 
-	public java.util.Collection<Object> getSessions(ConfigWeb config) throws PageException {
-		return register(config).sessions.values();
+	public java.util.Collection<Object> getSessions(ConfigWeb config) {
+		return getOrCreateData(config).sessions.values();
 	}
 
-	public void setSessions(ConfigWeb config, Object session) throws PageException {
-		register(config).sessions.put(WSUtil.getId(config, session), session);
+	public void setSessions(ConfigWeb config, Object session) {
+		getOrCreateData(config).sessions.put(WSUtil.getId(config, session), session);
 	}
 
-	public void remSessions(ConfigWeb config, Object session) throws PageException {
-		register(config).sessions.remove(WSUtil.getId(config, session));
+	public void remSessions(ConfigWeb config, Object session) {
+		getOrCreateData(config).sessions.remove(WSUtil.getId(config, session));
 	}
 
-	public long getRequestTimeout(ConfigWeb cw) throws PageException {
-		return register(cw).requestTimeout;
+	public long getRequestTimeout(ConfigWeb cw) {
+		return getOrCreateData(cw).requestTimeout;
 	}
 
-	public long getIdleTimeout(ConfigWeb cw) throws PageException {
-		return register(cw).idleTimeout;
+	public long getIdleTimeout(ConfigWeb cw) {
+		return getOrCreateData(cw).idleTimeout;
 	}
 
 	private static class Data {

--- a/source/java/src/org/lucee/extension/websocket/util/WSUtil.java
+++ b/source/java/src/org/lucee/extension/websocket/util/WSUtil.java
@@ -245,7 +245,13 @@ public class WSUtil {
 		if (!res.isFile()) {
 			info(pc.getConfig(), "creating configuration file at  [" + res + "], using default settings");
 			res.getParentResource().mkdirs();
-			eng.getIOUtil().write(res, "{\n\t\"directory\":\"" + DEFAULT_DIRECTORY + "\", \n\t\"requestTimeout\":50, \n\t\"idleTimeout\":300\n}", false, utf8);
+			try {
+				eng.getIOUtil().write(res, "{\n\t\"directory\":\"" + DEFAULT_DIRECTORY + "\", \n\t\"requestTimeout\":50, \n\t\"idleTimeout\":300\n}", false, utf8);
+			}
+			catch (IOException e) {
+				// another thread may have created the file concurrently, that's fine
+				if (!res.isFile() || res.length() == 0) throw e;
+			}
 		}
 
 		info(pc.getConfig(), "found configuration at  [" + res + "]");


### PR DESCRIPTION
## Summary

- Fix race condition where two threads compete to create `websocket.json`, causing `FileAlreadyExistsException` that permanently leaves `mapping` null
- Restructure `WebSocketEndpointFactory` init into clear separated concerns: `getOrCreateData()`, `initContextComponents()`, `registerEndpoint()`
- Lazy retry for mapping init — if first attempt fails, next call to `getComponentMapping()` or `getInfo()` retries instead of returning broken state
- Fix `inject()` self-delegation causing infinite recursion in `onError`
- Registrar thread only scans for new web contexts and registers endpoints, no longer attempts mapping init
- Disabled warmup step in CI to prove cold-start works without masking race conditions

## Test plan

- [x] CI green on both Lucee 6.2 and 7.0 without warmup
- [ ] Manual test with `test-local.sh` on both versions

Fixes https://luceeserver.atlassian.net/browse/LDEV-6179